### PR TITLE
Add basic support for aliases

### DIFF
--- a/conf.d/abbr_tips.fish
+++ b/conf.d/abbr_tips.fish
@@ -37,10 +37,12 @@ function __abbr_tips --on-event fish_postexec -d "Abbreviation reminder for the 
         set -l alias_value
 
         if string match -q '*=*' "$command[2]"
-            set command_split (string split = $command[2])
-            set alias_key $command_split[1]
-            set alias_value $command_split[2]
-            set -a alias_value $command[3..-1]
+            if test (count $command) = 2
+                set command_split (string split = $command[2])
+                set alias_key $command_split[1]
+                set alias_value $command_split[2]
+                set -a alias_value $command[3..-1]
+            end
         else
             set alias_key $command[2]
             set alias_value $command[3..-1]

--- a/conf.d/abbr_tips.fish
+++ b/conf.d/abbr_tips.fish
@@ -33,14 +33,18 @@ function __abbr_tips --on-event fish_postexec -d "Abbreviation reminder for the 
         end
     else if test "$command[1]" = "alias"
         # Update abbreviations list when adding aliases
-        and not contains -- "$command[2]" $__ABBR_TIPS_KEYS
-        if test (count $command) = 2
+        if string match -q '*=*' "$command[2]"
             set command_split (string split = $command[2])
-            set -a __ABBR_TIPS_KEYS $command_split[1]
-            set -a __ABBR_TIPS_VALUES $command_split[2]
+            set -a command_split $command[3..-1]
+            if not contains -- "$command_split[1]" $__ABBR_TIPS_KEYS
+                set -a __ABBR_TIPS_KEYS $command_split[1]
+                set -a __ABBR_TIPS_VALUES (string trim -c '\'"' $command_split[2..-1] | string join ' ')
+            end
         else
-            set -a __ABBR_TIPS_KEYS $command[2]
-            set -a __ABBR_TIPS_VALUES $command[3]
+            if not contains -- "$command[2]" $__ABBR_TIPS_KEYS
+                set -a __ABBR_TIPS_KEYS $command[2]
+                set -a __ABBR_TIPS_VALUES (string trim -c '\'"' $command[3..-1] | string join ' ')
+            end
         end
     else if test "$command[1]" = "functions"
         # Update abbreviations list when removing aliases

--- a/conf.d/abbr_tips.fish
+++ b/conf.d/abbr_tips.fish
@@ -39,16 +39,16 @@ function __abbr_tips --on-event fish_postexec -d "Abbreviation reminder for the 
         if string match -q '*=*' "$command[2]"
             if test (count $command) = 2
                 set command_split (string split = $command[2])
-                set alias_key $command_split[1]
+                set alias_key "a__$command_split[1]"
                 set alias_value $command_split[2]
                 set -a alias_value $command[3..-1]
             end
         else
-            set alias_key $command[2]
+            set alias_key "a__$command[2]"
             set alias_value $command[3..-1]
         end
 
-        if set -l abb (contains -i -- "$command[3]" $__ABBR_TIPS_KEYS)
+        if set -l abb (contains -i -- "$command[3..-1]" $__ABBR_TIPS_KEYS)
             set __ABBR_TIPS_KEYS[$abb] $alias_key
             set __ABBR_TIPS_VALUES[$abb] (string trim -c '\'"' -- $alias_value | string join ' ')
         else
@@ -58,7 +58,7 @@ function __abbr_tips --on-event fish_postexec -d "Abbreviation reminder for the 
     else if test "$command[1]" = "functions"
         # Update abbreviations list when removing aliases
         and string match -q -r '^--erase|-e$' -- "$command[2]"
-        and set -l abb (contains -i -- "$command[3]" $__ABBR_TIPS_KEYS)
+        and set -l abb (contains -i -- a__{$command[3]} $__ABBR_TIPS_KEYS)
         set -e __ABBR_TIPS_KEYS[$abb]
         set -e __ABBR_TIPS_VALUES[$abb]
     end
@@ -92,8 +92,19 @@ function __abbr_tips --on-event fish_postexec -d "Abbreviation reminder for the 
     end
 
     if test -n "$abb"
-        echo -e (string replace -a '{{ .cmd }}' "$__ABBR_TIPS_VALUES[$abb]" \
-                (string replace -a '{{ .abbr }}' "$__ABBR_TIPS_KEYS[$abb]" "$ABBR_TIPS_PROMPT"))
+        if string match -q "a__*" "$__ABBR_TIPS_KEYS[$abb]"
+            set -l alias (string sub -s 4 "$__ABBR_TIPS_KEYS[$abb]")
+            if functions -q "$alias"
+                echo -e (string replace -a '{{ .cmd }}' "$__ABBR_TIPS_VALUES[$abb]" \
+                        (string replace -a '{{ .abbr }}' "$alias" "$ABBR_TIPS_PROMPT"))
+            else
+                set -e __ABBR_TIPS_KEYS[$abb]
+                set -e __ABBR_TIPS_VALUES[$abb]
+            end
+        else
+            echo -e (string replace -a '{{ .cmd }}' "$__ABBR_TIPS_VALUES[$abb]" \
+                    (string replace -a '{{ .abbr }}' "$__ABBR_TIPS_KEYS[$abb]" "$ABBR_TIPS_PROMPT"))
+        end
     end
 
     return

--- a/conf.d/abbr_tips.fish
+++ b/conf.d/abbr_tips.fish
@@ -48,10 +48,10 @@ function __abbr_tips --on-event fish_postexec -d "Abbreviation reminder for the 
 
         if set -l abb (contains -i -- "$command[3]" $__ABBR_TIPS_KEYS)
             set __ABBR_TIPS_KEYS[$abb] $alias_key
-            set __ABBR_TIPS_VALUES[$abb] (string trim -c '\'"' $alias_value | string join ' ')
+            set __ABBR_TIPS_VALUES[$abb] (string trim -c '\'"' -- $alias_value | string join ' ')
         else
             set -a __ABBR_TIPS_KEYS $alias_key
-            set -a __ABBR_TIPS_VALUES (string trim -c '\'"' $alias_value | string join ' ')
+            set -a __ABBR_TIPS_VALUES (string trim -c '\'"' -- $alias_value | string join ' ')
         end
     else if test "$command[1]" = "functions"
         # Update abbreviations list when removing aliases

--- a/conf.d/abbr_tips.fish
+++ b/conf.d/abbr_tips.fish
@@ -34,8 +34,14 @@ function __abbr_tips --on-event fish_postexec -d "Abbreviation reminder for the 
     else if test "$command[1]" = "alias"
         # Update abbreviations list when adding aliases
         and not contains -- "$command[2]" $__ABBR_TIPS_KEYS
-        set -a __ABBR_TIPS_KEYS $command[2]
-        set -a __ABBR_TIPS_VALUES $command[3]
+        if test (count $command) = 2
+            set command_split (string split = $command[2])
+            set -a __ABBR_TIPS_KEYS $command_split[1]
+            set -a __ABBR_TIPS_VALUES $command_split[2]
+        else
+            set -a __ABBR_TIPS_KEYS $command[2]
+            set -a __ABBR_TIPS_VALUES $command[3]
+        end
     else if test "$command[1]" = "functions"
         # Update abbreviations list when removing aliases
         and string match -q -r '^--erase|-e$' -- "$command[2]"

--- a/conf.d/abbr_tips.fish
+++ b/conf.d/abbr_tips.fish
@@ -31,6 +31,17 @@ function __abbr_tips --on-event fish_postexec -d "Abbreviation reminder for the 
                 set -e __ABBR_TIPS_KEYS[$abb]
                 set -e __ABBR_TIPS_VALUES[$abb]
         end
+    else if test "$command[1]" = "alias"
+        # Update abbreviations list when adding aliases
+        and not contains -- "$command[2]" $__ABBR_TIPS_KEYS
+        set -a __ABBR_TIPS_KEYS $command[2]
+        set -a __ABBR_TIPS_VALUES $command[3]
+    else if test "$command[1]" = "functions"
+        # Update abbreviations list when removing aliases
+        and string match -q -r '^--erase|-e$' -- "$command[2]"
+        and set -l abb (contains -i -- "$command[3]" $__ABBR_TIPS_KEYS)
+        set -e __ABBR_TIPS_KEYS[$abb]
+        set -e __ABBR_TIPS_VALUES[$abb]
     end
 
     # Exit in the following cases :
@@ -44,9 +55,8 @@ function __abbr_tips --on-event fish_postexec -d "Abbreviation reminder for the 
     else if abbr -q "$cmd"
        or not type -q "$command[1]"
        return
-    else if test (type -t "$command[1]") = 'function'
-       and not contains "$command[1]" $ABBR_TIPS_ALIAS_WHITELIST
-       return
+    else if alias | grep -q "^alias $cmd "
+        return
     end
 
     set -l abb

--- a/conf.d/abbr_tips.fish
+++ b/conf.d/abbr_tips.fish
@@ -33,18 +33,22 @@ function __abbr_tips --on-event fish_postexec -d "Abbreviation reminder for the 
         end
     else if test "$command[1]" = "alias"
         # Update abbreviations list when adding aliases
+        set -l alias_key
+        set -l alias_value
+
         if string match -q '*=*' "$command[2]"
             set command_split (string split = $command[2])
-            set -a command_split $command[3..-1]
-            if not contains -- "$command_split[1]" $__ABBR_TIPS_KEYS
-                set -a __ABBR_TIPS_KEYS $command_split[1]
-                set -a __ABBR_TIPS_VALUES (string trim -c '\'"' $command_split[2..-1] | string join ' ')
-            end
+            set alias_key $command_split[1]
+            set alias_value $command_split[2]
+            set -a alias_value $command[3..-1]
         else
-            if not contains -- "$command[2]" $__ABBR_TIPS_KEYS
-                set -a __ABBR_TIPS_KEYS $command[2]
-                set -a __ABBR_TIPS_VALUES (string trim -c '\'"' $command[3..-1] | string join ' ')
-            end
+            set alias_key $command[2]
+            set alias_value $command[3..-1]
+        end
+
+        if not contains -- "$alias_key" $__ABBR_TIPS_KEYS
+            set -a __ABBR_TIPS_KEYS $alias_key
+            set -a __ABBR_TIPS_VALUES (string trim -c '\'"' $alias_value | string join ' ')
         end
     else if test "$command[1]" = "functions"
         # Update abbreviations list when removing aliases

--- a/conf.d/abbr_tips.fish
+++ b/conf.d/abbr_tips.fish
@@ -63,6 +63,10 @@ function __abbr_tips --on-event fish_postexec -d "Abbreviation reminder for the 
        return
     else if alias | grep -q "^alias $cmd "
         return
+    else if test (type -t "$command[1]") = 'function'
+        and count $ABBR_TIPS_ALIAS_WHITELIST >/dev/null
+        and not contains "$command[1]" $ABBR_TIPS_ALIAS_WHITELIST
+        return
     end
 
     set -l abb

--- a/conf.d/abbr_tips.fish
+++ b/conf.d/abbr_tips.fish
@@ -46,7 +46,10 @@ function __abbr_tips --on-event fish_postexec -d "Abbreviation reminder for the 
             set alias_value $command[3..-1]
         end
 
-        if not contains -- "$alias_key" $__ABBR_TIPS_KEYS
+        if set -l abb (contains -i -- "$command[3]" $__ABBR_TIPS_KEYS)
+            set __ABBR_TIPS_KEYS[$abb] $alias_key
+            set __ABBR_TIPS_VALUES[$abb] (string trim -c '\'"' $alias_value | string join ' ')
+        else
             set -a __ABBR_TIPS_KEYS $alias_key
             set -a __ABBR_TIPS_VALUES (string trim -c '\'"' $alias_value | string join ' ')
         end

--- a/conf.d/abbr_tips.fish
+++ b/conf.d/abbr_tips.fish
@@ -61,7 +61,7 @@ function __abbr_tips --on-event fish_postexec -d "Abbreviation reminder for the 
     else if abbr -q "$cmd"
        or not type -q "$command[1]"
        return
-    else if alias | grep -q "^alias $cmd "
+    else if string match -q "alias $cmd *" (alias)
         return
     else if test (type -t "$command[1]") = 'function'
         and count $ABBR_TIPS_ALIAS_WHITELIST >/dev/null

--- a/functions/__abbr_tips_init.fish
+++ b/functions/__abbr_tips_init.fish
@@ -12,4 +12,13 @@ function __abbr_tips_init -d "Initialize abbreviations variables for fish-abbr-t
         set -a __ABBR_TIPS_VALUES  (string trim -c '\'' "$current_abb[2]")
         set i (math $i + 1)
     end
+
+    set -l i 1
+    set -l abb (string replace -r '.*-- ' '' (alias -s))
+    while test $i -le (count $abb)
+        set -l current_abb (string split -m2 ' ' "$abb[$i]")
+        set -a __ABBR_TIPS_KEYS "$current_abb[2]"
+        set -a __ABBR_TIPS_VALUES (string trim -c '\'' "$current_abb[3]")
+        set i (math $i + 1)
+    end
 end

--- a/functions/__abbr_tips_init.fish
+++ b/functions/__abbr_tips_init.fish
@@ -9,7 +9,7 @@ function __abbr_tips_init -d "Initialize abbreviations variables for fish-abbr-t
     while test $i -le (count $abb)
         set -l current_abb (string split -m1 ' ' "$abb[$i]")
         set -a __ABBR_TIPS_KEYS "$current_abb[1]"
-        set -a __ABBR_TIPS_VALUES  (string trim -c '\'' "$current_abb[2]")
+        set -a __ABBR_TIPS_VALUES (string trim -c '\'' "$current_abb[2]")
         set i (math $i + 1)
     end
 
@@ -17,7 +17,7 @@ function __abbr_tips_init -d "Initialize abbreviations variables for fish-abbr-t
     set -l abb (string replace -r '.*-- ' '' (alias -s))
     while test $i -le (count $abb)
         set -l current_abb (string split -m2 ' ' "$abb[$i]")
-        set -a __ABBR_TIPS_KEYS "$current_abb[2]"
+        set -a __ABBR_TIPS_KEYS "a__$current_abb[2]"
         set -a __ABBR_TIPS_VALUES (string trim -c '\'' "$current_abb[3]")
         set i (math $i + 1)
     end


### PR DESCRIPTION
## Description

Adds abbreviations to the dictionary when initially loading and when running the `alias` command. Closes #1.

## Notes

Aliases are just a shortcut for writing functions, so if an alias is defined using the function command this won't catch it.

Previously the alias whitelist feature meant that by default no aliases would be checked, which doesn’t make sense if aliases are actually supported. Now the whitelist will only apply at all if it’s not empty: an empty whitelist will allow all aliases. (I also wondered if a blacklist would be useful, but that could be a separate PR if it’s a feature you’re interested in.)