### PR TITLE
Handle commandlines starting with `-`

### DIFF
--- a/functions/__abbr_tips_bind_space.fish
+++ b/functions/__abbr_tips_bind_space.fish
@@ -1,7 +1,7 @@
 function __abbr_tips_bind_space
     commandline -i " "
     if test $__abbr_tips_used != 1
-        if abbr -q (string trim (commandline))
+        if abbr -q -- (string trim -- (commandline))
             set -g __abbr_tips_used 1
         else
             set -g __abbr_tips_used 0


### PR DESCRIPTION
If I type (for example) `-s` followed by a space at the beginning of the input (in order to use fish’s history search feature), then I get the following error:

```
string trim: Unknown option '-s '
```

If `--` is added to the `string trim` command, then the following error occurs instead:

```
abbr: Mutually exclusive flags 'q/query' and `s/show` seen
```

Adding `--` to both commands works as expected.