### PR TITLE
fix typo on CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Please open an issue and discuss the problem / feature before starting to code.
 
 - Keep the style consistent with existent code.
 - Stay with pure fish (use builtins)
-- Avoid dependancies
+- Avoid dependencies
 
 ## Git Commit Messages
 


### PR DESCRIPTION
## Description
typo issue

## Related issues
typo inline 11
'dependancies'  should be 'dependencies'

## Notes
typo has been fixed