### PR TITLE
Add '--' to all calls to `string`

### DIFF
--- a/conf.d/abbr_tips.fish
+++ b/conf.d/abbr_tips.fish
@@ -25,8 +25,8 @@ function __abbr_tips_install --on-event abbr_tips_install
 end
 
 function __abbr_tips --on-event fish_postexec -d "Abbreviation reminder for the current command"
-    set -l command (string split ' ' "$argv")
-    set -l cmd (string replace -r -a '\\s+' ' ' "$argv" )
+    set -l command (string split ' ' -- "$argv")
+    set -l cmd (string replace -r -a '\\s+' ' ' -- "$argv" )
 
     # Update abbreviations lists when adding/removing abbreviations
     if test "$command[1]" = "abbr"
@@ -46,7 +46,7 @@ function __abbr_tips --on-event fish_postexec -d "Abbreviation reminder for the 
 
         if string match -q '*=*' -- "$command[2]"
             if test (count $command) = 2
-                set command_split (string split = $command[2])
+                set command_split (string split '=' -- $command[2])
                 set alias_key "a__$command_split[1]"
                 set alias_value $command_split[2]
                 set -a alias_value $command[3..-1]
@@ -82,7 +82,7 @@ function __abbr_tips --on-event fish_postexec -d "Abbreviation reminder for the 
     else if abbr -q "$cmd"
         or not type -q "$command[1]"
         return
-    else if string match -q "alias $cmd *" (alias)
+    else if string match -q -- "alias $cmd *" (alias)
         return
     else if test (type -t "$command[1]") = 'function'
         and count $ABBR_TIPS_ALIAS_WHITELIST >/dev/null
@@ -100,18 +100,18 @@ function __abbr_tips --on-event fish_postexec -d "Abbreviation reminder for the 
     end
 
     if test -n "$abb"
-        if string match -q "a__*" "$__ABBR_TIPS_KEYS[$abb]"
-            set -l alias (string sub -s 4 "$__ABBR_TIPS_KEYS[$abb]")
+        if string match -q "a__*" -- "$__ABBR_TIPS_KEYS[$abb]"
+            set -l alias (string sub -s 4 -- "$__ABBR_TIPS_KEYS[$abb]")
             if functions -q "$alias"
-                echo -e (string replace -a '{{ .cmd }}' "$__ABBR_TIPS_VALUES[$abb]" \
-                        (string replace -a '{{ .abbr }}' "$alias" "$ABBR_TIPS_PROMPT"))
+                echo -e (string replace -a '{{ .cmd }}' -- "$__ABBR_TIPS_VALUES[$abb]" \
+                        (string replace -a '{{ .abbr }}' -- "$alias" "$ABBR_TIPS_PROMPT"))
             else
                 set -e __ABBR_TIPS_KEYS[$abb]
                 set -e __ABBR_TIPS_VALUES[$abb]
             end
         else
-            echo -e (string replace -a '{{ .cmd }}' "$__ABBR_TIPS_VALUES[$abb]" \
-                    (string replace -a '{{ .abbr }}' "$__ABBR_TIPS_KEYS[$abb]" "$ABBR_TIPS_PROMPT"))
+            echo -e (string replace -a '{{ .cmd }}' -- "$__ABBR_TIPS_VALUES[$abb]" \
+                    (string replace -a '{{ .abbr }}' -- "$__ABBR_TIPS_KEYS[$abb]" "$ABBR_TIPS_PROMPT"))
         end
     end
 

--- a/functions/__abbr_tips_bind_newline.fish
+++ b/functions/__abbr_tips_bind_newline.fish
@@ -1,6 +1,6 @@
 function __abbr_tips_bind_newline
     if test $__abbr_tips_used != 1
-        if abbr -q (string trim (commandline))
+        if abbr -q (string trim -- (commandline))
             set -g __abbr_tips_used 1
         else
             set -g __abbr_tips_used 0

--- a/functions/__abbr_tips_bind_newline.fish
+++ b/functions/__abbr_tips_bind_newline.fish
@@ -1,6 +1,6 @@
 function __abbr_tips_bind_newline
     if test $__abbr_tips_used != 1
-        if abbr -q (string trim -- (commandline))
+        if abbr -q -- (string trim -- (commandline))
             set -g __abbr_tips_used 1
         else
             set -g __abbr_tips_used 0

--- a/functions/__abbr_tips_init.fish
+++ b/functions/__abbr_tips_init.fish
@@ -5,7 +5,7 @@ function __abbr_tips_init -d "Initialize abbreviations variables for fish-abbr-t
     set -Ux __ABBR_TIPS_VALUES
 
     set -l i 1
-    set -l abb (string replace -r '.*-- ' '' (abbr -s))
+    set -l abb (string replace -r '.*-- ' '' -- (abbr -s))
     while test $i -le (count $abb)
         set -l current_abb (string split -m1 ' ' "$abb[$i]")
         set -a __ABBR_TIPS_KEYS "$current_abb[1]"
@@ -14,7 +14,7 @@ function __abbr_tips_init -d "Initialize abbreviations variables for fish-abbr-t
     end
 
     set -l i 1
-    set -l abb (string replace -r '.*-- ' '' (alias -s))
+    set -l abb (string replace -r '.*-- ' '' -- (alias -s))
     while test $i -le (count $abb)
         set -l current_abb (string split -m2 ' ' "$abb[$i]")
         set -a __ABBR_TIPS_KEYS "a__$current_abb[2]"


### PR DESCRIPTION
## Description
Initially looked into this to solve the following bug:
```
❯ ls \
      --foobarstring trim: Unknown option '--foobar'

~/.config/fish/functions/__abbr_tips_bind_newline.fish (line 1):
in command substitution
	called on line 3 of file ~/.config/fish/functions/__abbr_tips_bind_newline.fish
in function '__abbr_tips_bind_newline'

(Type 'help string' for related documentation)

ls: unrecognized option '--foobar'
Try 'ls --help' for more information.
```

Then went ahead and made the same changes across the plugin.

With the changes to `functions/__abbr_tips_bind_newline.fish` the error message is prevented:
```
❯ fisher install matiasjrossi/fish-abbreviation-tips
fisher install version 4.3.0
Fetching https://codeload.github.com/matiasjrossi/fish-abbreviation-tips/tar.gz/HEAD
Installing matiasjrossi/fish-abbreviation-tips
           /home/matiasr/.config/fish/functions/__abbr_tips_bind_newline.fish
           /home/matiasr/.config/fish/functions/__abbr_tips_bind_space.fish
           /home/matiasr/.config/fish/functions/__abbr_tips_init.fish
           /home/matiasr/.config/fish/conf.d/abbr_tips.fish
Installed 1 plugin/s


❯ ls \
      --foobar
ls: unrecognized option '--foobar'
Try 'ls --help' for more information.

❯ git status
fatal: not a git repository (or any of the parent directories): .git

💡 gs => git status
```

## Related issues
N/A

## Notes
Tests passing.
