### PR TITLE
Add escape for string split

### DIFF
--- a/functions/__abbr_tips_init.fish
+++ b/functions/__abbr_tips_init.fish
@@ -7,18 +7,18 @@ function __abbr_tips_init -d "Initialize abbreviations variables for fish-abbr-t
     set -l i 1
     set -l abb (string replace -r '.*-- ' '' -- (abbr -s))
     while test $i -le (count $abb)
-        set -l current_abb (string split -m1 ' ' "$abb[$i]")
+        set -l current_abb (string split -m1 -- ' ' "$abb[$i]")
         set -a __ABBR_TIPS_KEYS "$current_abb[1]"
-        set -a __ABBR_TIPS_VALUES (string trim -c '\'' "$current_abb[2]")
+        set -a __ABBR_TIPS_VALUES (string trim -c -- '\'' "$current_abb[2]")
         set i (math $i + 1)
     end
 
     set -l i 1
     set -l abb (string replace -r '.*-- ' '' -- (alias -s))
     while test $i -le (count $abb)
-        set -l current_abb (string split -m2 ' ' "$abb[$i]")
+        set -l current_abb (string split -m2 -- ' ' "$abb[$i]")
         set -a __ABBR_TIPS_KEYS "a__$current_abb[2]"
-        set -a __ABBR_TIPS_VALUES (string trim -c '\'' "$current_abb[3]")
+        set -a __ABBR_TIPS_VALUES (string trim -c -- '\'' "$current_abb[3]")
         set i (math $i + 1)
     end
 end


### PR DESCRIPTION
## Description

Add escape `--` to the string split

See the following error:

```sh
string split: Unknown option “- 'cd -'”

~/.config/fish/fisher/functions/__abbr_tips_init.fish (line 1): 
string split -m1 ' ' "$abb[$i]"
^
in command substitution
	called on line 10 of file ~/.config/fish/fisher/functions/__abbr_tips_init.fish
in function '__abbr_tips_init'
```

If the abbreviation starts with `-` it will errors out. This PR adds `--` to escape possible invalid string

## Related issues

## Notes