### PR TITLE
Fix bug in __abbr_tips_init.fish

### DIFF
--- a/functions/__abbr_tips_init.fish
+++ b/functions/__abbr_tips_init.fish
@@ -9,7 +9,7 @@ function __abbr_tips_init -d "Initialize abbreviations variables for fish-abbr-t
     while test $i -le (count $abb)
         set -l current_abb (string split -m1 -- ' ' "$abb[$i]")
         set -a __ABBR_TIPS_KEYS "$current_abb[1]"
-        set -a __ABBR_TIPS_VALUES (string trim -c -- '\'' "$current_abb[2]")
+        set -a __ABBR_TIPS_VALUES (string trim -c '\'' -- "$current_abb[2]")
         set i (math $i + 1)
     end
 
@@ -18,7 +18,7 @@ function __abbr_tips_init -d "Initialize abbreviations variables for fish-abbr-t
     while test $i -le (count $abb)
         set -l current_abb (string split -m2 -- ' ' "$abb[$i]")
         set -a __ABBR_TIPS_KEYS "a__$current_abb[2]"
-        set -a __ABBR_TIPS_VALUES (string trim -c -- '\'' "$current_abb[3]")
+        set -a __ABBR_TIPS_VALUES (string trim -c '\'' -- "$current_abb[3]")
         set i (math $i + 1)
     end
 end

--- a/test/fish-abbreviation-tips.fish
+++ b/test/fish-abbreviation-tips.fish
@@ -15,10 +15,10 @@ function setup
 end
 
 function teardown
-  # Restore variables
-  set __ABBR_TIPS_KEYS $tmp_keys
-  set __ABBR_TIPS_VALUES $tmp_values
-  set ABBR_TIPS_PROMPT "$tmp_tips_prompt"
+    # Restore variables
+    set __ABBR_TIPS_KEYS $tmp_keys
+    set __ABBR_TIPS_VALUES $tmp_values
+    set ABBR_TIPS_PROMPT "$tmp_tips_prompt"
 end
 
 function clear_test_var

--- a/test/fish-abbreviation-tips.fish
+++ b/test/fish-abbreviation-tips.fish
@@ -26,6 +26,9 @@ function clear_test_var
     # of each unit test from affecting each other
     set -g __ABBR_TIPS_KEYS
     set -g __ABBR_TIPS_VALUES
+    abbr -e __abbr_test
+    abbr -e __abbr_test_one
+    abbr -e __abbr_test_two
 end
 
 setup
@@ -135,5 +138,21 @@ setup
   __abbr_tips 'alias __abbr_test_alias "grep -q"'
   echo (__abbr_tips 'grep -q')
 ) = "__abbr_test_alias => grep -q"
+
+@test "multiple abbreviation tip match" (
+  clear_test_var
+  abbr -a __abbr_test_one ps
+  abbr -a __abbr_test_two "grep -q"
+  __abbr_tips_init
+  echo (__abbr_tips 'grep -q')
+) = "__abbr_test_two => grep -q"
+
+@test "multiple alias tip match" (
+  clear_test_var
+  alias abbr_test_alias_one ps
+  alias abbr_test_alias_two "grep -q"
+  __abbr_tips_init
+  echo (__abbr_tips 'grep -q')
+) = "abbr_test_alias_two => grep -q"
 
 teardown


### PR DESCRIPTION
## Description
closes #21.

## Related issues

## Notes
Due to `--` at incorrect position in `string trim` command in `functions/__abbr_tips_init.fish` incorrect values were being appended to the variable `__ABBR_TIPS_VALUES`.